### PR TITLE
Add file-based persistence, Vite scaffolding, and Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+data.json
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+data.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY server.js .
+EXPOSE 3001
+CMD ["node", "server.js"]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Meal Planner</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.jsx"></script>
+  </body>
+</html>

--- a/main.jsx
+++ b/main.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import MealPlanner from "./meal-planner.jsx";
+
+createRoot(document.getElementById("root")).render(<MealPlanner />);

--- a/meal-planner.jsx
+++ b/meal-planner.jsx
@@ -1,5 +1,35 @@
 import { useState, useEffect } from "react";
 
+const SERVER = "";
+
+function useFileStorage(key, initial) {
+  const [value, setValue] = useState(() =>
+    typeof initial === "function" ? initial() : initial
+  );
+
+  // Load persisted value from server on mount
+  useEffect(() => {
+    fetch(`${SERVER}/data`)
+      .then(r => r.json())
+      .then(data => { if (key in data && data[key] !== null) setValue(data[key]); })
+      .catch(() => {});
+  }, []);
+
+  const set = (newValueOrFn) => {
+    setValue(prev => {
+      const next = typeof newValueOrFn === "function" ? newValueOrFn(prev) : newValueOrFn;
+      fetch(`${SERVER}/data/${key}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(next),
+      }).catch(() => {});
+      return next;
+    });
+  };
+
+  return [value, set];
+}
+
 const DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
 const SHORT_DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
@@ -28,9 +58,11 @@ const initialPlan = () => {
 };
 
 export default function MealPlanner() {
-  const [plan, setPlan] = useState(initialPlan());
-  const [dishes, setDishes] = useState(SAMPLE_DISHES);
-  const [freezer, setFreezer] = useState(SAMPLE_FREEZER);
+  // Dynamic: resets/changes week to week
+  const [plan, setPlan] = useFileStorage("mp_plan", initialPlan);
+  const [freezer, setFreezer] = useFileStorage("mp_freezer", SAMPLE_FREEZER);
+  // Static: personal dish library, rarely changes
+  const [dishes, setDishes] = useFileStorage("mp_dishes", SAMPLE_DISHES);
   const [activeTab, setActiveTab] = useState("plan");
   const [activeDay, setActiveDay] = useState("Monday");
   const [showAddDish, setShowAddDish] = useState(false);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "meal-planner",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "concurrently \"node server.js\" \"vite\"",
+    "build": "vite build",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "concurrently": "^9.1.2",
+    "vite": "^6.0.11"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,66 @@
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const DB = "./data.json";
+const DIST = path.join(__dirname, "dist");
+
+const MIME = {
+  ".html": "text/html",
+  ".js":   "text/javascript",
+  ".css":  "text/css",
+  ".svg":  "image/svg+xml",
+  ".png":  "image/png",
+  ".ico":  "image/x-icon",
+};
+
+const read = () => {
+  try { return JSON.parse(fs.readFileSync(DB, "utf8")); }
+  catch { return {}; }
+};
+
+const write = (data) => fs.writeFileSync(DB, JSON.stringify(data, null, 2));
+
+const serveStatic = (req, res) => {
+  const filePath = path.join(DIST, req.url === "/" ? "index.html" : req.url);
+  const fallback = path.join(DIST, "index.html");
+  const target = fs.existsSync(filePath) ? filePath : fallback;
+  const ext = path.extname(target);
+  res.setHeader("Content-Type", MIME[ext] || "application/octet-stream");
+  res.writeHead(200);
+  res.end(fs.readFileSync(target));
+};
+
+const server = http.createServer((req, res) => {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, PATCH, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") { res.writeHead(204); res.end(); return; }
+
+  if (req.method === "GET" && req.url === "/data") {
+    res.setHeader("Content-Type", "application/json");
+    res.writeHead(200);
+    res.end(JSON.stringify(read()));
+    return;
+  }
+
+  if (req.method === "PATCH" && req.url.startsWith("/data/")) {
+    const key = req.url.slice(6);
+    let body = "";
+    req.on("data", chunk => body += chunk);
+    req.on("end", () => {
+      const db = read();
+      db[key] = JSON.parse(body);
+      write(db);
+      res.setHeader("Content-Type", "application/json");
+      res.writeHead(200);
+      res.end(JSON.stringify({ ok: true }));
+    });
+    return;
+  }
+
+  serveStatic(req, res);
+});
+
+server.listen(3001, () => console.log("Server → http://localhost:3001"));

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      "/data": "http://localhost:3001",
+    },
+  },
+});


### PR DESCRIPTION
## What changed

- **Persistence** — replaced `useState` with a `useFileStorage` hook that reads from and writes to `data.json` via a local Node HTTP server. Dynamic state (weekly plan, freezer) and static state (dish library) are stored under separate keys.
- **Server** (`server.js`) — Node built-in HTTP server with a `GET /data` + `PATCH /data/:key` API and static file serving from `dist/` for production.
- **Vite scaffolding** — added `package.json`, `index.html`, `main.jsx`, and `vite.config.js`. Dev server proxies `/data` to the Node server so relative URLs work in both dev and Docker.
- **Docker** — multi-stage `Dockerfile` (Vite build stage → lean `node:alpine` runtime, no `node_modules` in final image) exposing port `3001`.
- **Ignores** — `.gitignore` and `.dockerignore` excluding `node_modules`, `dist`, and `data.json` (runtime file, should be volume-mounted in Docker).

## Running locally
\`\`\`bash
npm install && npm run dev   # Vite on :5173, data server on :3001
\`\`\`

## Running in Docker
\`\`\`bash
docker build -t meal-planner .
docker run -p 3001:3001 -v \$(pwd)/data.json:/app/data.json meal-planner
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)